### PR TITLE
Check for XAUDIO2_DEFAULT_CHANNELS inside CreateMasteringVoice

### DIFF
--- a/x3daudio1_7/xaudio2-hook/graph/AudioGraphMapper.cpp
+++ b/x3daudio1_7/xaudio2-hook/graph/AudioGraphMapper.cpp
@@ -140,6 +140,13 @@ IXAudio2SubmixVoice* AudioGraphMapper::CreateSubmixVoice(UINT32 InputChannels, U
 
 IXAudio2MasteringVoice* AudioGraphMapper::CreateMasteringVoice(UINT32 InputChannels, UINT32 InputSampleRate, UINT32 Flags, UINT32 DeviceIndex, const XAUDIO2_EFFECT_CHAIN* pEffectChain)
 {
+	if (InputChannels == XAUDIO2_DEFAULT_CHANNELS)
+	{
+		// Change the InputChannels that are stored in XAudio2MasteringVoiceProxy, in case game requests it later
+		// (as mentioned below, we only make use of 2 channels here)
+		InputChannels = 2;
+	}
+	
 	auto proxyVoice = new XAudio2MasteringVoiceProxy(InputChannels, InputSampleRate, Flags, DeviceIndex, from_XAUDIO2_EFFECT_CHAIN(pEffectChain));
 
 	// For HRTF only two-channel mastering voice makes sense.


### PR DESCRIPTION
This fixes Resident Evil 4 where it creates voice with `XAUDIO2_DEFAULT_CHANNELS` (0), then tries requesting number of channels later on, but would have issues with `InputChannels` = 0.

Maybe it should always be changing `InputChannels` to 2 instead of checking for `XAUDIO2_DEFAULT_CHANNELS` though, depends on whether storing the original `InputChannels` is on purpose (eg. to pretend to game that it's still using the `InputChannels` that it specified), not sure if that's the case or not.